### PR TITLE
fix: Resolve ReferenceError in payrollController.js

### DIFF
--- a/server/controllers/payrollController.js
+++ b/server/controllers/payrollController.js
@@ -244,5 +244,4 @@ module.exports = {
     updatePayslipStatus,
     updatePayrollSettings,
     // Expose for testing or direct use if needed
-    _internal: { calculateNSSF, calculateNHIF, calculatePAYE }
 };


### PR DESCRIPTION
Removed an incorrect `_internal` export from `module.exports` in `server/controllers/payrollController.js`. This export was attempting to reference functions (`calculateNSSF`, `calculateNHIF`, `calculatePAYE`) that are defined in `payrollService.js` and not within the local scope of the controller, leading to a `ReferenceError`.

These calculation functions are used internally by the `processEmployeePayroll` service function and can be tested by directly importing them from `payrollService.js` if needed. The controller itself does not need to re-export them.