### PR TITLE
Fix: Correct Vite proxy rewrite for /api routes

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -8,8 +8,8 @@ export default defineConfig({
     proxy: {
       '/api': { // Match paths starting with /api
         target: 'http://localhost:5001', // Proxy to this backend
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, '') // Remove /api prefix when forwarding
+        changeOrigin: true
+        // rewrite: (path) => path.replace(/^\/api/, '') // Remove /api prefix when forwarding
       }
     }
   }


### PR DESCRIPTION
The Vite development server proxy was configured to rewrite paths starting with /api by removing the /api prefix before forwarding to the backend. However, your backend server expects routes to be prefixed with /api (e.g., /api/auth/login).

This mismatch caused a 404 error when your client attempted to POST to /api/auth/login, as the backend received a request for /auth/login which it was not configured to handle.

This commit removes the `rewrite` option from the Vite proxy configuration in `client/vite.config.js`. Now, requests made by your client to paths like /api/auth/login will be correctly proxied to the backend as http://localhost:5001/api/auth/login, aligning with your backend's routing setup.