### PR TITLE
Fix: Resolve multiple JSX and import errors across pages and layouts

### DIFF
--- a/client/src/layouts/MainLayout.jsx
+++ b/client/src/layouts/MainLayout.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Outlet, Link, useNavigate } from 'react-router-dom';
-import { useAuth } from '../../store/authContext'; // Adjust path if necessary
+import { useAuth } from '../store/authContext'; // Adjust path if necessary
 
 // Basic Footer component (can be enhanced or moved later)
 const Footer = () => {

--- a/client/src/pages/departments/DepartmentFormModal.jsx
+++ b/client/src/pages/departments/DepartmentFormModal.jsx
@@ -75,40 +75,9 @@ const DepartmentFormModal = ({ department, onClose }) => {
                             </button>
                         </div>
                     </form>
-                </div>
-
-
-
-        <div style={modalStyle}>
-            <div style={modalContentStyle}>
-                <h3>{isEditMode ? 'Edit Department' : 'Add New Department'}</h3>
-                <form onSubmit={handleSubmit}>
-                    {error && <p className="text-danger">{error}</p>}
-                    <div className="mb-3">
-                        <label htmlFor="deptName" className="form-label">Name:</label>
-                        <input type="text" id="deptName" className="form-control" value={name} onChange={(e) => setName(e.target.value)} required />
-                    </div>
-                    <div className="mb-3">
-                        <label htmlFor="deptStatus" className="form-label">Status:</label>
-                        <select id="deptStatus" className="form-select" value={status} onChange={(e) => setStatus(e.target.value)}>
-                            <option value="ACTIVE">Active</option>
-                            <option value="INACTIVE">Inactive</option>
-                        </select>
-                    </div>
-                    <div className="mt-3">
-                        <button type="submit" className="btn btn-success" disabled={loading}>
-                            {loading ? (isEditMode ? 'Updating...' : 'Creating...') : (isEditMode ? 'Save Changes' : 'Create Department')}
-                        </button>
-                        <button type="button" className="btn btn-success ms-2" onClick={onClose} disabled={loading}>
-                            Cancel
-                        </button>
-                    </div>
-                </form>
-
-
-
-            </div>
-        </div>
+                </div> {/* Closing modal-content */}
+            </div> {/* Closing modal-dialog */}
+        </div> /* Closing modal */
     );
 };
 export default DepartmentFormModal;

--- a/client/src/pages/departments/DepartmentListPage.jsx
+++ b/client/src/pages/departments/DepartmentListPage.jsx
@@ -50,13 +50,7 @@ const DepartmentListPage = () => {
             {departments.length === 0 ? (
                 <p>No departments found.</p>
             ) : (
-                <table className="table table-striped table-hover">
-
-
-                <table className="table table-striped table-hover">
-
                 <table className="table table-bordered table-striped">
-
                     <thead>
                         <tr>
                             <th>Name</th>

--- a/client/src/pages/employees/EmployeeForm.jsx
+++ b/client/src/pages/employees/EmployeeForm.jsx
@@ -258,20 +258,11 @@ const EmployeeForm = ({ isEditMode = false }) => {
                                     </button>
                                 </div>
                             </form>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-                <button type="button" className="btn btn-secondary ms-2" onClick={() => navigate('/employees')}>Cancel</button>
-
-
-                <button type="button" className="btn btn-secondary ms-2" onClick={() => navigate('/employees')}>Cancel</button>
-                <button type="button" className="btn btn-success ms-2" onClick={() => navigate('/employees')}>Cancel</button>
-
-            </form>
-
-        </div>
+                        </div> {/* Closing card-body */}
+                    </div> {/* Closing card */}
+                </div> {/* Closing col-lg-10 */}
+            </div> {/* Closing row */}
+        </div> // Closing container mt-4 mb-5
     );
 };
 

--- a/client/src/pages/employees/EmployeeListPage.jsx
+++ b/client/src/pages/employees/EmployeeListPage.jsx
@@ -30,30 +30,13 @@ const EmployeeListPage = () => {
     return (
         <div>
             <h2>Employee Management</h2>
-            <Link to="/employees/new" className="btn btn-success mb-3 d-inline-block">
-
-
-
-            <Link to="/employees/new" className="btn btn-success mb-3 d-inline-block">
-
             <Link to="/employees/new" className="btn btn-success mb-3">
-
-
-
                 Add New Employee
             </Link>
             {employees.length === 0 ? (
                 <p>No employees found.</p>
             ) : (
-                <table className="table table-striped table-hover">
-
-
-
-                <table className="table table-striped table-hover">
                 <table className="table table-bordered table-striped">
-
-
-
                     <thead>
                         <tr>
                             <th>Name</th>

--- a/client/src/pages/incomegrades/IncomeGradeFormModal.jsx
+++ b/client/src/pages/incomegrades/IncomeGradeFormModal.jsx
@@ -91,39 +91,9 @@ const IncomeGradeFormModal = ({ incomeGrade, onClose }) => {
                             </button>
                         </div>
                     </form>
-                </div>
-
-
-        <div style={modalStyle}>
-            <div style={modalContentStyle}>
-                <h3>{isEditMode ? 'Edit Income Grade' : 'Add New Income Grade'}</h3>
-                <form onSubmit={handleSubmit}>
-                    {error && <p className="text-danger">{error}</p>}
-                    <div className="mb-3"><label htmlFor="gradeName" className="form-label">Grade Name: </label><input type="text" name="gradeName" id="gradeName" className="form-control" value={formData.gradeName} onChange={handleChange} required /></div>
-                    <div className="mb-3"><label htmlFor="basicSalary" className="form-label">Basic Salary: </label><input type="number" name="basicSalary" id="basicSalary" className="form-control" value={formData.basicSalary} onChange={handleChange} required min="0" /></div>
-                    <div className="mb-3"><label htmlFor="houseAllowance" className="form-label">House Allowance: </label><input type="number" name="houseAllowance" id="houseAllowance" className="form-control" value={formData.houseAllowance} onChange={handleChange} min="0" /></div>
-                    <div className="mb-3"><label htmlFor="transportAllowance" className="form-label">Transport Allowance: </label><input type="number" name="transportAllowance" id="transportAllowance" className="form-control" value={formData.transportAllowance} onChange={handleChange} min="0" /></div>
-                    <div className="mb-3"><label htmlFor="hardshipAllowance" className="form-label">Hardship Allowance: </label><input type="number" name="hardshipAllowance" id="hardshipAllowance" className="form-control" value={formData.hardshipAllowance} onChange={handleChange} min="0" /></div>
-                    <div className="mb-3"><label htmlFor="specialAllowance" className="form-label">Special Allowance: </label><input type="number" name="specialAllowance" id="specialAllowance" className="form-control" value={formData.specialAllowance} onChange={handleChange} min="0" /></div>
-                    <div className="mb-3 form-check">
-                        <input type="checkbox" name="isActive" id="isActive" className="form-check-input" checked={formData.isActive} onChange={handleChange} />
-                        <label htmlFor="isActive" className="form-check-label"> Active</label>
-                    </div>
-
-                    <div className="mt-3">
-                        <button type="submit" className="btn btn-success" disabled={loading}>
-                            {loading ? (isEditMode ? 'Updating...' : 'Creating...') : (isEditMode ? 'Save Changes' : 'Create Grade')}
-                        </button>
-                        <button type="button" className="btn btn-success ms-2" onClick={onClose} disabled={loading}>
-                            Cancel
-                        </button>
-                    </div>
-                </form>
-
-
-
-            </div>
-        </div>
+                </div> {/* Closing modal-content */}
+            </div> {/* Closing modal-dialog */}
+        </div> /* Closing modal */
     );
 };
 export default IncomeGradeFormModal;

--- a/client/src/pages/incomegrades/IncomeGradeListPage.jsx
+++ b/client/src/pages/incomegrades/IncomeGradeListPage.jsx
@@ -51,16 +51,7 @@ const IncomeGradeListPage = () => {
             {incomeGrades.length === 0 ? (
                 <p>No income grades found.</p>
             ) : (
-                <table className="table table-striped table-hover">
-
-
-
-                <table className="table table-striped table-hover">
-
                 <table className="table table-bordered table-striped">
-
-
-
                     <thead>
                         <tr>
                             <th>Grade Name</th>

--- a/client/src/pages/payrollops/AdvanceFormModal.jsx
+++ b/client/src/pages/payrollops/AdvanceFormModal.jsx
@@ -125,42 +125,9 @@ const AdvanceFormModal = ({ item, onClose, operationType = "Advance" }) => {
                             </button>
                         </div>
                     </form>
-                </div>
-
-
-
-        <div style={modalStyle}>
-            <div style={modalContentStyle}>
-                <h3>{title}</h3>
-                <form onSubmit={handleSubmit}>
-                    {error && <p className="text-danger">{error}</p>}
-                    <div className="mb-3">
-                        <label htmlFor="employeeId" className="form-label">Employee:</label>
-                        <select name="employeeId" id="employeeId" className="form-select" value={formData.employeeId} onChange={handleChange} required disabled={isEditMode}>
-                            <option value="">Select Employee</option>
-                            {employees.map(emp => (
-                                <option key={emp._id} value={emp._id}>
-                                    {emp.firstName} {emp.lastName} ({emp.nationalId})
-                                </option>
-                            ))}
-                        </select>
-                    </div>
-                    <div className="mb-3"><label htmlFor="amount" className="form-label">Amount: </label><input type="number" name="amount" id="amount" className="form-control" value={formData.amount} onChange={handleChange} required min="0.01" step="0.01" /></div>
-                    <div className="mb-3"><label htmlFor="dateIssued" className="form-label">Date Issued: </label><input type="date" name="dateIssued" id="dateIssued" className="form-control" value={formData.dateIssued} onChange={handleChange} required /></div>
-                    <div className="mb-3"><label htmlFor="reason" className="form-label">Reason: </label><textarea name="reason" id="reason" className="form-control" value={formData.reason} onChange={handleChange} rows="2"></textarea></div>
-                    <div className="mt-3">
-                        <button type="submit" className="btn btn-success" disabled={loading || (isEditMode && !item)}>
-                            {loading ? 'Saving...' : (isEditMode ? 'Save Changes' : `Record ${operationType}`)}
-                        </button>
-                        <button type="button" className="btn btn-success ms-2" onClick={onClose} disabled={loading}>
-                            Cancel
-                        </button>
-                    </div>
-                </form>
-
-
-            </div>
-        </div>
+                </div> {/* Closing modal-content */}
+            </div> {/* Closing modal-dialog */}
+        </div> /* Closing modal */
     );
 };
 export default AdvanceFormModal;

--- a/client/src/pages/payrollops/AdvanceListPage.jsx
+++ b/client/src/pages/payrollops/AdvanceListPage.jsx
@@ -63,14 +63,7 @@ const AdvanceListPage = () => {
             {advances.length === 0 ? (
                 <p>No advances found.</p>
             ) : (
-                <table className="table table-striped table-hover">
-
-
-
-                <table className="table table-striped table-hover">
                 <table className="table table-bordered table-striped">
-
-
                     <thead>
                         <tr>
                             <th>Employee</th>
@@ -99,19 +92,8 @@ const AdvanceListPage = () => {
                                 <td>
                                     {(userInfo.role === 'company_admin' || userInfo.role === 'hr_manager' || userInfo.role === 'employee_admin') && item.status === 'PENDING' && (
                                         <>
-
                                             <button onClick={() => handleStatusUpdate(item._id, 'APPROVED')} className="btn btn-sm btn-success">Approve</button>
                                             <button onClick={() => handleStatusUpdate(item._id, 'REJECTED')} className="btn btn-sm btn-warning ms-1">Reject</button>
-
-
-                                            <button onClick={() => handleStatusUpdate(item._id, 'APPROVED')} className="btn btn-sm btn-success">Approve</button>
-                                            <button onClick={() => handleStatusUpdate(item._id, 'REJECTED')} className="btn btn-sm btn-warning ms-1">Reject</button>
-
-                                            <button onClick={() => handleStatusUpdate(item._id, 'APPROVED')} className="btn btn-sm btn-success">Approve</butt
-                                            <button onClick={() => handleStatusUpdate(item._id, 'REJECTED')} className="btn btn-sm btn-warning ms-1">Reject</button>
-
-                                            <button onClick={() => handleStatusUpdate(item._id, 'REJECTED')} className="btn btn-sm btn-success ms-1">Reject</button>
-
                                         </>
                                     )}
                                 </td>

--- a/client/src/pages/payrolls/PayrollListPage.jsx
+++ b/client/src/pages/payrolls/PayrollListPage.jsx
@@ -75,24 +75,7 @@ const PayrollListPage = () => {
                     {months.map(m => <option key={m} value={m}>{m}</option>)}
                 </select>
                 <select value={filterYear} onChange={e => setFilterYear(parseInt(e.target.value))} className="form-select form-select-sm" style={{width: 'auto'}}> {/* Added form-select, width auto */}
-
-
-
-            <div className="mb-3 d-flex align-items-center"> {/* Added d-flex for better alignment */}
-                <span className="me-2">Filter by:</span> {/* Added span and margin for label */}
-                <select value={filterMonth} onChange={e => setFilterMonth(e.target.value)} className="form-select form-select-sm me-2" style={{width: 'auto'}}> {/* Added form-select, width auto */}
-                    {months.map(m => <option key={m} value={m}>{m}</option>)}
-                </select>
-                <select value={filterYear} onChange={e => setFilterYear(parseInt(e.target.value))} className="form-select form-select-sm" style={{width: 'auto'}}> {/* Added form-select, width auto */}
-            <div className="mb-3 d-flex align-items-center">
-                <span className="me-2">Filter by:</span>
-                <select value={filterMonth} onChange={e => setFilterMonth(e.target.value)} className="form-select form-select-sm d-inline-block w-auto ms-2">
-                    {months.map(m => <option key={m} value={m}>{m}</option>)}
-                </select>
-                <select value={filterYear} onChange={e => setFilterYear(parseInt(e.target.value))} className="form-select form-select-sm d-inline-block w-auto ms-2">
-
-
-                     {years.map(y => <option key={y} value={y}>{y}</option>)}
+                    {years.map(y => <option key={y} value={y}>{y}</option>)}
                 </select>
             </div>
 
@@ -101,19 +84,7 @@ const PayrollListPage = () => {
             {!loading && !error && payrolls.length === 0 && <p>No payroll records found for {filterMonth}, {filterYear}.</p>}
 
             {!loading && !error && payrolls.length > 0 && (
-
-                <table className="table table-striped table-hover">
-
-
-                <table className="table table-striped table-hover">
-
- fix/bootstrap
-                <table className="table table-striped table-hover">
-
                 <table className="table table-bordered table-striped">
-
-
-
                     <thead>
                         <tr>
                             <th>Employee</th>


### PR DESCRIPTION
This commit addresses a series of JSX parsing errors and an import path issue in several files.

The initial issue was an 'Unterminated JSX contents' error in `PayrollListPage.jsx`. Subsequent error logs revealed similar issues in other list pages and various form modal components, as well as an incorrect import path in `MainLayout.jsx`.

Changes made:
- Corrected JSX structure in the following files by removing duplicated elements (tables, buttons, entire modal structures) and ensuring proper tag closure and nesting:
    - `client/src/pages/payrolls/PayrollListPage.jsx`
    - `client/src/pages/employees/EmployeeListPage.jsx`
    - `client/src/pages/employees/EmployeeForm.jsx`
    - `client/src/pages/departments/DepartmentListPage.jsx`
    - `client/src/pages/incomegrades/IncomeGradeListPage.jsx`
    - `client/src/pages/payrollops/AdvanceListPage.jsx`
    - `client/src/pages/payrollops/AdvanceFormModal.jsx`
    - `client/src/pages/departments/DepartmentFormModal.jsx`
    - `client/src/pages/incomegrades/IncomeGradeFormModal.jsx`
- Corrected a malformed button tag in `AdvanceListPage.jsx`.
- Fixed an incorrect import path for `authContext` in `client/src/layouts/MainLayout.jsx`.

The primary cause of the JSX errors appeared to be copy-paste mistakes leading to duplicated content and mismatched tags. The modal components, in particular, had entire duplicated structures that were removed.