### PR TITLE
Refactor: Relocate module.exports to end of controller files

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -143,14 +143,6 @@ const getMe = async (req, res) => {
     });
 };
 
-
-module.exports = {
-    registerCompanyAdmin,
-    loginUser,
-    getMe,
-    changePassword // Added changePassword to exports
-};
-
 // @desc    Change user password
 // @route   POST /api/auth/change-password
 // @access  Private
@@ -188,4 +180,11 @@ const changePassword = async (req, res) => {
         console.error('Change password error:', error);
         res.status(500).json({ message: 'Server error during password change.', error: error.message });
     }
+};
+
+module.exports = {
+    registerCompanyAdmin,
+    loginUser,
+    getMe,
+    changePassword // Added changePassword to exports
 };

--- a/server/controllers/payrollController.js
+++ b/server/controllers/payrollController.js
@@ -261,17 +261,6 @@ const updatePayrollSettings = async (req, res) => {
     }
 };
 
-
-module.exports = {
-    runPayroll,
-    getPayrolls,
-    getPayslipById,
-    updatePayslipStatus,
-    updatePayrollSettings,
-    getUpcomingPaymentDates // Added export
-    // Expose for testing or direct use if needed
-};
-
 // @desc    Get upcoming payment dates (placeholder logic)
 // @route   GET /api/payrolls/upcoming-payment-dates
 // @access  Private (Authenticated users)
@@ -309,4 +298,14 @@ const getUpcomingPaymentDates = async (req, res) => {
         console.error('Get upcoming payment dates error:', error);
         res.status(500).json({ message: 'Server error fetching upcoming payment dates.', error: error.message });
     }
+};
+
+module.exports = {
+    runPayroll,
+    getPayrolls,
+    getPayslipById,
+    updatePayslipStatus,
+    updatePayrollSettings,
+    getUpcomingPaymentDates // Added export
+    // Expose for testing or direct use if needed
 };


### PR DESCRIPTION
I moved the `module.exports` statement to the end of the file in:
- server/controllers/authController.js
- server/controllers/payrollController.js

This change adheres to common JavaScript module patterns, placing exports at the end of the file for better readability and consistency.