### PR TITLE
feat: Implement file uploads in chat module

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const path = require('path'); // Added path module
 const dotenv = require('dotenv');
 const cors = require('cors');
 const connectDB = require('./config/db');
@@ -21,6 +22,9 @@ const app = express();
 // Middleware
 app.use(cors());
 app.use(express.json());
+
+// Serve static files from the 'uploads' directory
+app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
 // Simple Route
 app.get('/', (req, res) => {


### PR DESCRIPTION
This commit introduces file uploading capabilities to the chat feature.

Key changes include:
- Client-side logic in ChatPage.jsx to handle file selection, create FormData, and call the upload API.
- Server-side:
    - Multer configuration in messageController.js for file storage in `server/uploads/`, file type filtering (jpeg, png, gif, pdf), and size limits (5MB).
    - New API endpoint POST /api/messages/upload/:conversationId for handling file uploads.
    - Uploaded file information (fileName, fileUrl, contentType, etc.) is stored in the Message model.
    - Socket.IO event `newMessage` is emitted to update clients in real-time.
- Added static file serving for the `server/uploads` directory in `server/server.js` using `express.static` to make uploaded files accessible via URL.
- Implemented user feedback for loading states and error messages during the upload process on the client.

The system now allows you to select files, upload them to a selected conversation, and have them appear in the chat history for all participants. Error handling is in place for incorrect file types, exceeding size limits, or attempting to upload without selecting a conversation.