### PR TITLE
Fix: Resolve message content validation error for file uploads

### DIFF
--- a/server/controllers/messageController.js
+++ b/server/controllers/messageController.js
@@ -263,11 +263,10 @@ const uploadFileForConversation = async (req, res) => {
         res.status(201).json(populatedFileMessage);
 
     } catch (error) {
+        console.error('Original error during file upload:', error);
         console.error('Error uploading file:', error);
-        if (req.file && req.file.path) {
-            if (fs.existsSync(req.file.path)) {
-                 fs.unlinkSync(req.file.path);
-            }
+        if (req.file && req.file.path && fs.existsSync(req.file.path)) {
+            fs.unlinkSync(req.file.path);
         }
         if (error.message.startsWith('Invalid file type')) {
              return res.status(400).json({ message: error.message });

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -19,8 +19,9 @@ const messageSchema = new mongoose.Schema({
     // Let's keep it simple for now and rely on conversation.participants.
     content: {
         type: String,
-        required: true,
+        required: false, // Changed from true to false
         trim: true,
+        default: '', // Optionally, provide a default empty string
     },
     contentType: { // E.g., 'text', 'image', 'file', 'pdf'
         type: String,


### PR DESCRIPTION
I modified the `Message` schema in `server/models/Message.js` to make the `content` field optional. I changed `required: true` to `required: false` and added `default: ''` for the `content` field.

This change addresses a Mongoose validation error (`Path 'content' is required`) that occurred when attempting to save a message associated with a file upload where the text content was an empty string. By making the content field optional, messages that are primarily file-based (e.g., images, PDFs) can be saved without requiring textual content, thus resolving the 500 server error during file uploads.