### PR TITLE
feat: Update sidebar modules and add Employee Self Service

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -15,6 +15,10 @@ import ViewEmployeePage from './pages/employees/ViewEmployeePage';
 import MyPayslipsPage from './pages/employees/MyPayslipsPage'; // Existing, may be different from new PaystubsPage
 import PaystubsPage from './pages/PaystubsPage'; // New page for /my-paystubs
 
+// Employee Self-Service Pages
+import TaxFormsPage from './pages/employee_self_service/TaxFormsPage';
+import LeavePage from './pages/employee_self_service/LeavePage';
+import PersonalInformationPage from './pages/employee_self_service/PersonalInformationPage';
 
 // Department Pages
 import DepartmentListPage from './pages/departments/DepartmentListPage';
@@ -140,6 +144,23 @@ function AppContent() {
         <Route path="/my-benefits" element={
           <ProtectedRoute roles={['employee']}>
             <BenefitsPage />
+          </ProtectedRoute>
+        } />
+
+        {/* Employee Self-Service Routes */}
+        <Route path="/my-tax-forms" element={
+          <ProtectedRoute roles={['employee']}>
+            <TaxFormsPage />
+          </ProtectedRoute>
+        } />
+        <Route path="/my-leave" element={
+          <ProtectedRoute roles={['employee']}>
+            <LeavePage />
+          </ProtectedRoute>
+        } />
+        <Route path="/my-personal-info" element={
+          <ProtectedRoute roles={['employee']}>
+            <PersonalInformationPage />
           </ProtectedRoute>
         } />
 

--- a/client/src/components/common/Sidebar.jsx
+++ b/client/src/components/common/Sidebar.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
 import styles from './Sidebar.module.css';
 import {
-  FaBars, FaTachometerAlt, FaFileInvoiceDollar, FaUsers, FaChartBar, FaCog, FaQuestionCircle, FaSignOutAlt, FaUserCircle, FaAngleDown, FaAngleRight, FaTimes
+  FaBars, FaTachometerAlt, FaFileInvoiceDollar, FaUsers, FaChartBar, FaCog, FaQuestionCircle, FaSignOutAlt, FaUserCircle, FaAngleDown, FaAngleRight, FaTimes, FaHistory, FaComments, FaEnvelope, FaUserCheck, FaMoneyBillWave, FaLeaf, FaFileContract, FaCalendarAlt, FaIdCard
 } from 'react-icons/fa';
 
 const navItems = [
@@ -15,13 +15,25 @@ const navItems = [
     path: '/',
   },
   {
+    id: 'employeeSelfService',
+    text: 'Employee Self Service',
+    icon: <FaUserCheck />,
+    path: '/my-personal-info', // Default path for the parent item
+    subItems: [
+      { id: 'myPaystubs', text: 'Paystubs', path: '/my-paystubs', icon: <FaMoneyBillWave className={styles.submenuIcon} /> },
+      { id: 'myBenefits', text: 'Benefits', path: '/my-benefits', icon: <FaLeaf className={styles.submenuIcon} /> },
+      { id: 'myTaxForms', text: 'Tax Forms', path: '/my-tax-forms', icon: <FaFileContract className={styles.submenuIcon} /> },
+      { id: 'myLeave', text: 'Leave', path: '/my-leave', icon: <FaCalendarAlt className={styles.submenuIcon} /> },
+      { id: 'myPersonalInfo', text: 'Personal Information', path: '/my-personal-info', icon: <FaIdCard className={styles.submenuIcon} /> },
+    ],
+  },
+  {
     id: 'payrollProcessing',
     text: 'Payroll Processing',
     icon: <FaFileInvoiceDollar />,
     path: '/payrolls',
     subItems: [
       { id: 'runPayroll', text: 'Run Payroll', path: '/payrolls/run', icon: <FaAngleRight className={styles.submenuIcon} /> },
-      { id: 'payrollHistory', text: 'Payroll History', path: '/payrolls', icon: <FaAngleRight className={styles.submenuIcon} /> },
     ],
   },
   {
@@ -38,7 +50,19 @@ const navItems = [
     id: 'reportsAnalytics',
     text: 'Reports & Analytics',
     icon: <FaChartBar />,
-    path: '/reports',
+    path: '/reports', // This path might need to be adjusted if it's a parent now
+    subItems: [
+      { id: 'payrollHistoryReport', text: 'Payroll History', path: '/payrolls', icon: <FaHistory className={styles.submenuIcon} /> },
+    ],
+  },
+  {
+    id: 'communication',
+    text: 'Communication',
+    icon: <FaComments />,
+    path: '/communication', // Define a base path, can be adjusted later
+    subItems: [
+      { id: 'messages', text: 'Messages', path: '/messages', icon: <FaEnvelope className={styles.submenuIcon} /> },
+    ],
   },
   {
     id: 'configurationAdmin',

--- a/client/src/pages/employee_self_service/LeavePage.jsx
+++ b/client/src/pages/employee_self_service/LeavePage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const LeavePage = () => {
+  return (
+    <div>
+      <h2>Leave Page</h2>
+      <p>Content to be added.</p>
+    </div>
+  );
+};
+
+export default LeavePage;

--- a/client/src/pages/employee_self_service/PersonalInformationPage.jsx
+++ b/client/src/pages/employee_self_service/PersonalInformationPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const PersonalInformationPage = () => {
+  return (
+    <div>
+      <h2>Personal Information Page</h2>
+      <p>Content to be added.</p>
+    </div>
+  );
+};
+
+export default PersonalInformationPage;

--- a/client/src/pages/employee_self_service/TaxFormsPage.jsx
+++ b/client/src/pages/employee_self_service/TaxFormsPage.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const TaxFormsPage = () => {
+  return (
+    <div>
+      <h2>Tax Forms: Understanding Your P9 Form</h2>
+      <p>This page provides information about important tax documents, primarily the P9 form, which is essential for filing your annual individual income tax returns with the Kenya Revenue Authority (KRA).</p>
+
+      <h3>P9 Form (PAYE Summary Form)</h3>
+      <p><strong>Purpose:</strong> The P9 form is a summary of your earnings and tax deductions for a given tax year (January 1st to December 31st). It is issued by your employer.</p>
+      <p><strong>Content:</strong> A P9 form typically includes the following details:</p>
+      <ul>
+        <li>Gross Pay (including basic salary, benefits, and allowances)</li>
+        <li>Taxable Pay</li>
+        <li>Total PAYE (Pay As You Earn) tax deducted and remitted by your employer throughout the year</li>
+        <li>Pension Contributions (if applicable)</li>
+        <li>Personal Relief entitlement</li>
+      </ul>
+      <p><strong>Use:</strong> You will use the information on your P9 form to file your annual Individual Income Tax Returns (ITR) with KRA. For employed individuals, KRA often provides a pre-filled Excel-based return form that is linked to your P9 data.</p>
+      <p><strong>Payroll System Role:</strong> The payroll system is responsible for accurately calculating all the figures required for the P9 form. Ideally, a printable or downloadable P9 form for each employee should be accessible through an Employee Self-Service (ESS) portal like this one.</p>
+
+      <h4>Other Important Tax Information:</h4>
+      <ul>
+        <li><strong>Individual Income Tax Return (ITR):</strong> This is the declaration form you submit to KRA annually. If you have no other sources of income, your P9 will be the primary document for this. If you have no income for the year but have a KRA PIN, you must still file a "Nil Return."</li>
+        <li><strong>Tax Compliance Certificate (TCC):</strong> This is official proof from KRA that you have complied with your tax obligations. While the payroll system doesn't issue TCCs, accurate PAYE calculations and remittances by your employer (facilitated by the payroll system) are crucial for obtaining a TCC.</li>
+      </ul>
+
+      <p><em>Note: This page is for informational purposes. Actual P9 forms and tax filing should be done in accordance with KRA guidelines.</em></p>
+    </div>
+  );
+};
+
+export default TaxFormsPage;

--- a/client/src/pages/payrolls/PayrollListPage.jsx
+++ b/client/src/pages/payrolls/PayrollListPage.jsx
@@ -64,11 +64,6 @@ const PayrollListPage = () => {
     return (
         <div>
             <h2>Payroll Records</h2>
-            {(userInfo.role === 'company_admin' || userInfo.role === 'hr_manager' || userInfo.role === 'employee_admin') && (
-                <button onClick={handleRunPayroll} className="btn btn-success mb-3">
-                    Run New Payroll
-                </button>
-            )}
             <div className="mb-3 d-flex align-items-center"> {/* Added d-flex for better alignment */}
                 <span className="me-2">Filter by:</span> {/* Added span and margin for label */}
                 <select value={filterMonth} onChange={e => setFilterMonth(e.target.value)} className="form-select form-select-sm me-2" style={{width: 'auto'}}> {/* Added form-select, width auto */}


### PR DESCRIPTION
This commit introduces several enhancements to the application navigation and features:

1.  **Payroll History Relocation**:
    *   Moved "Payroll History" from "Payroll Processing" to the "Reports & Analytics" section in the sidebar.
    *   Removed the "Run New Payroll" button from the "Payroll History" page (`PayrollListPage.jsx`) as it's now primarily for viewing history.

2.  **Communication Module**:
    *   Added a new "Communication" module to the sidebar.
    *   Included a "Messages" link under this module, pointing to the existing chat functionality.

3.  **Employee Self Service (ESS) Module**:
    *   Created a new "Employee Self Service" module in the sidebar.
    *   Added links for:
        *   "Paystubs" (to `/my-paystubs`).
        *   "Benefits" (to `/my-benefits`).
        *   "Tax Forms" (to `/my-tax-forms`): This page now displays informational content about the P9 tax form for employees.
        *   "Leave" (to `/my-leave`): Placeholder page created.
        *   "Personal Information" (to `/my-personal-info`): Placeholder page created.
    *   Ensured these new ESS pages are accessible via the 'employee' role. Access roles for these pages were simplified to `['employee']` to resolve a routing issue where they were previously defaulting to the dashboard.

All related routing and sidebar navigation items have been updated accordingly. Placeholder pages for Leave and Personal Information are ready for future content.