### PR TITLE
Fix: Ensure sidebar defaults to light theme consistently

### DIFF
--- a/client/src/components/common/Sidebar.jsx
+++ b/client/src/components/common/Sidebar.jsx
@@ -86,7 +86,8 @@ const navItems = [
   },
 ];
 
-const Sidebar = ({ theme = 'dark', onDesktopToggle, initialDesktopCollapsed = false, isMobileOpen = false, onMobileToggle, onLogoutClick, userInfo }) => {
+// Defaulting theme prop to 'light' as a safeguard, though MainLayout should always pass 'light'.
+const Sidebar = ({ theme = 'light', onDesktopToggle, initialDesktopCollapsed = false, isMobileOpen = false, onMobileToggle, onLogoutClick, userInfo }) => {
   const [isDesktopCollapsed, setIsDesktopCollapsed] = useState(initialDesktopCollapsed);
   const [openAccordionSubmenu, setOpenAccordionSubmenu] = useState(null); // For accordion
   const [hoveredFlyoutParentId, setHoveredFlyoutParentId] = useState(null); // For flyout

--- a/client/src/components/common/Sidebar.module.css
+++ b/client/src/components/common/Sidebar.module.css
@@ -1,62 +1,41 @@
 /* client/src/components/common/Sidebar.module.css */
-/* ... (existing variables and styles up to .submenu) ... */
+
+/* Common sidebar structural variables (not theme-specific colors) */
 :root {
-  /* Common */
   --sidebar-transition-duration: 0.3s;
   --sidebar-icon-size: 20px;
   --sidebar-collapsed-icon-size: 22px;
   --sidebar-submenu-icon-size: 16px;
-
-  /* Dark Theme Colors (as per issue) */
-  --dark-bg: #2C3E50;
-  --dark-text: #ECF0F1;
-  --dark-active-bg: #3498DB;
-  --dark-active-text: #FFFFFF;
-  --dark-hover-bg: #34495E;
-  --dark-border: #34495E;
-  --dark-submenu-bg: rgba(0,0,0,0.15); /* Current one, can be derived from main colors */
-  --dark-logout-hover-bg: #c0392b;
-  --dark-logout-text: #bdc3c7;
-
-  /* Light Theme Colors (as per issue) */
-  --light-bg: #F8F9FA;
-  --light-text: #495057;
-  --light-active-bg: #E2F1FB; /* Very Light Blue */
-  --light-active-text: #007BFF; /* Medium Blue */
-  --light-hover-bg: #E9ECEF; /* Slightly Darker Light Grey */
-  --light-border: #DEE2E6; /* Example border for light theme */
-  --light-submenu-bg: rgba(0,0,0,0.05);
-  --light-logout-hover-bg: #dc3545; /* Bootstrap danger red */
-  --light-logout-text: #6c757d; /* Bootstrap secondary text */
 }
 
-/* Theme Classes */
+/* Theme Classes - These will now map to the global theme variables from theme.css */
 .darkTheme {
-  --sidebar-bg-color: var(--dark-bg);
-  --sidebar-text-color: var(--dark-text);
-  --sidebar-active-bg-color: var(--dark-active-bg);
-  --sidebar-active-text-color: var(--dark-active-text);
-  --sidebar-hover-bg-color: var(--dark-hover-bg);
-  --sidebar-border-color: var(--dark-border);
-  --sidebar-submenu-bg-color: var(--dark-submenu-bg);
-  --sidebar-logout-text-color: var(--dark-logout-text);
-  --sidebar-logout-hover-bg-color: var(--dark-logout-hover-bg);
-  --sidebar-focus-ring-color: var(--dark-active-bg); /* For focus outline */
+  --sidebar-bg-color: var(--theme-dark-sidebar-bg);
+  --sidebar-text-color: var(--theme-dark-sidebar-text);
+  --sidebar-active-bg-color: var(--theme-dark-sidebar-active-bg);
+  --sidebar-active-text-color: var(--theme-dark-sidebar-active-text);
+  --sidebar-hover-bg-color: var(--theme-dark-sidebar-hover-bg);
+  --sidebar-border-color: var(--theme-dark-sidebar-border);
+  --sidebar-submenu-bg-color: var(--theme-dark-sidebar-submenu-bg);
+  --sidebar-logout-text-color: var(--theme-dark-sidebar-logout-text);
+  --sidebar-logout-hover-bg-color: var(--theme-dark-sidebar-logout-hover-bg);
+  --sidebar-focus-ring-color: var(--theme-dark-sidebar-focus-ring);
 }
 
 .lightTheme {
-  --sidebar-bg-color: var(--light-bg);
-  --sidebar-text-color: var(--light-text);
-  --sidebar-active-bg-color: var(--light-active-bg);
-  --sidebar-active-text-color: var(--light-active-text);
-  --sidebar-hover-bg-color: var(--light-hover-bg);
-  --sidebar-border-color: var(--light-border);
-  --sidebar-submenu-bg-color: var(--light-submenu-bg);
-  --sidebar-logout-text-color: var(--light-logout-text);
-  --sidebar-logout-hover-bg-color: var(--light-logout-hover-bg);
-  --sidebar-focus-ring-color: var(--light-active-text); /* For focus outline */
+  --sidebar-bg-color: var(--theme-light-sidebar-bg);
+  --sidebar-text-color: var(--theme-light-sidebar-text);
+  --sidebar-active-bg-color: var(--theme-light-sidebar-active-bg);
+  --sidebar-active-text-color: var(--theme-light-sidebar-active-text);
+  --sidebar-hover-bg-color: var(--theme-light-sidebar-hover-bg);
+  --sidebar-border-color: var(--theme-light-sidebar-border);
+  --sidebar-submenu-bg-color: var(--theme-light-sidebar-submenu-bg);
+  --sidebar-logout-text-color: var(--theme-light-sidebar-logout-text);
+  --sidebar-logout-hover-bg-color: var(--theme-light-sidebar-logout-hover-bg);
+  --sidebar-focus-ring-color: var(--theme-light-sidebar-focus-ring);
 }
 
+/* Styles below this point use the --sidebar-*** variables defined by .lightTheme or .darkTheme */
 
 .sidebar {
   background-color: var(--sidebar-bg-color);
@@ -313,7 +292,7 @@
   .sidebar.desktopCollapsed .userProfile .userDetails { display: none !important; }
   .sidebar.desktopCollapsed .userProfile .avatarContainer { margin-bottom: 10px !important; }
   .sidebar.desktopCollapsed .submenu.accordionActive { display: none !important; } /* Ensure accordion is hidden on tablet collapsed */
-  .sidebar.desktopCollapsed .submenu.flyoutActive { /* Flyouts should still work on tablet */ }
+  /* Removed empty .sidebar.desktopCollapsed .submenu.flyoutActive {} rule that was reportedly causing issues */
 }
 
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,43 @@
+/* client/src/index.css */
+@import './theme.css';
+
+/* Other global styles can go here */
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  /* The theme.css already applies default background and text color to body */
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}
+
+/* Ensure Bootstrap is loaded before this if not handled by JS imports */
+/* If Bootstrap is imported via JS (e.g. in index.jsx or App.jsx),
+   its styles will be injected. We can override them here or in theme.css */
+
+/* Example of overriding Bootstrap variables (if not using SASS build) */
+/* These are already in theme.css but shown here for clarity */
+/*
+:root {
+  --bs-primary: var(--theme-light-accent-primary);
+  --bs-secondary: var(--theme-light-accent-secondary);
+  --bs-body-bg: var(--theme-light-bg-primary);
+  --bs-body-color: var(--theme-light-text-primary);
+  --bs-border-color: var(--theme-light-border-primary);
+}
+
+.theme-dark {
+  --bs-primary: var(--theme-dark-accent-primary);
+  --bs-secondary: var(--theme-dark-accent-secondary);
+  --bs-body-bg: var(--theme-dark-bg-primary);
+  --bs-body-color: var(--theme-dark-text-primary);
+  --bs-border-color: var(--theme-dark-border-primary);
+}
+*/

--- a/client/src/layouts/MainLayout.jsx
+++ b/client/src/layouts/MainLayout.jsx
@@ -71,7 +71,9 @@ const MainLayout = () => {
     setIsMobileSidebarOpen(typeof openState === 'boolean' ? openState : !isMobileSidebarOpen);
   };
 
-  const sidebarTheme = 'dark';
+  const currentTheme = 'light'; // Set 'light' as the default theme
+  // const sidebarTheme = 'dark'; // Previous hardcoded theme
+  const sidebarTheme = currentTheme; // Sidebar theme will match the current application theme
 
   const handleLogout = () => {
     logout(); // This is from useAuth()
@@ -91,7 +93,7 @@ const MainLayout = () => {
 
 
   return (
-    <div className={`${styles.mainLayout} ${isMobileSidebarOpen ? styles.mobileSidebarActive : ''}`}>
+    <div className={`${styles.mainLayout} ${isMobileSidebarOpen ? styles.mobileSidebarActive : ''} theme-${currentTheme}`}> {/* Added theme class */}
       <nav className={`navbar navbar-expand-lg navbar-light bg-light ${styles.appNavbar}`}>
         <div className="container-fluid">
           {/* Mobile Sidebar Toggle - visible only on small screens */}

--- a/client/src/layouts/MainLayout.module.css
+++ b/client/src/layouts/MainLayout.module.css
@@ -16,7 +16,8 @@
   padding: 20px;
   overflow-y: auto;
   transition: margin-left 0.3s ease-in-out;
-  background-color: #ffffff;
+  /* background-color will be inherited from body or specific theme class */
+  /* or explicitly set: background-color: var(--theme-light-bg-primary); */
 }
 
 .contentShiftExpanded {
@@ -37,8 +38,8 @@
 }
 
 .appFooter {
-    background-color: #343a40;
-    color: white;
+    background-color: var(--theme-light-footer-bg); /* Use theme variable */
+    color: var(--theme-light-footer-text);       /* Use theme variable */
     text-align: center;
     padding: 1rem;
 }

--- a/client/src/theme.css
+++ b/client/src/theme.css
@@ -1,0 +1,192 @@
+/* client/src/theme.css */
+:root {
+  /* Light Theme (Default) */
+  --theme-light-bg-primary: #FFFFFF; /* Page background */
+  --theme-light-bg-secondary: #F8F9FA; /* Card headers, slightly off-white sections */
+  --theme-light-bg-tertiary: #E9ECEF; /* Hover states, subtle backgrounds */
+
+  --theme-light-text-primary: #212529; /* Main text color */
+  --theme-light-text-secondary: #495057; /* Subtler text, placeholders */
+  --theme-light-text-accent: #007BFF; /* Links, primary action text */
+
+  --theme-light-border-primary: #DEE2E6; /* Standard borders */
+  --theme-light-border-secondary: #CED4DA; /* Stronger borders */
+
+  --theme-light-accent-primary: #007BFF; /* Primary buttons, active states */
+  --theme-light-accent-primary-rgb: 0,123,255;
+  --theme-light-accent-primary-hover: #0056b3;
+  --theme-light-accent-secondary: #6C757D; /* Secondary buttons */
+  --theme-light-accent-secondary-rgb: 108,117,125;
+  --theme-light-accent-secondary-hover: #545b62;
+
+  /* Additional component-specific variables */
+  --theme-light-success: var(--theme-light-accent-primary); /* Mapping success to primary for now */
+  --theme-light-success-rgb: var(--theme-light-accent-primary-rgb);
+  --theme-light-success-hover: var(--theme-light-accent-primary-hover);
+
+
+  /* RGB versions for text and background (if not already defined elsewhere) */
+  --theme-light-bg-primary-rgb: 255,255,255;
+  --theme-light-text-primary-rgb: 33,37,41;
+
+
+  /* Sidebar Specific (Light) - will be used by Sidebar.module.css */
+  --theme-light-sidebar-bg: #F8F9FA;
+  --theme-light-sidebar-text: #495057;
+  --theme-light-sidebar-active-bg: #E2F1FB;
+  --theme-light-sidebar-active-text: #007BFF;
+  --theme-light-sidebar-hover-bg: #E9ECEF;
+  --theme-light-sidebar-border: #DEE2E6;
+  --theme-light-sidebar-submenu-bg: rgba(0,0,0,0.05);
+  --theme-light-sidebar-logout-text: #6c757d;
+  --theme-light-sidebar-logout-hover-bg: #dc3545; /* Bootstrap danger */
+  --theme-light-sidebar-focus-ring: var(--theme-light-accent-primary);
+
+  --theme-light-footer-bg: #343a40; /* Existing color, but now as a variable */
+  --theme-light-footer-text: #FFFFFF;
+
+
+  /* Dark Theme (Define structure, can be populated later if theme switching is added) */
+  --theme-dark-bg-primary: #1A202C; /* Example: Dark page background */
+  --theme-dark-bg-secondary: #2D3748; /* Example: Dark card headers */
+  --theme-dark-bg-tertiary: #4A5568; /* Example: Dark hover states */
+
+  --theme-dark-text-primary: #F7FAFC; /* Example: Light text on dark background */
+  --theme-dark-text-secondary: #E2E8F0; /* Example: Subtler light text */
+  --theme-dark-text-accent: #3498DB; /* Example: Accent color for dark theme */
+
+  --theme-dark-border-primary: #4A5568;
+  --theme-dark-border-secondary: #718096;
+
+  --theme-dark-accent-primary: #3498DB;
+  --theme-dark-accent-primary-hover: #217dbb;
+  --theme-dark-accent-secondary: #BDC3C7;
+  --theme-dark-accent-secondary-hover: #95a5a6;
+
+  /* Sidebar Specific (Dark) - will be used by Sidebar.module.css */
+  --theme-dark-sidebar-bg: #2C3E50;
+  --theme-dark-sidebar-text: #ECF0F1;
+  --theme-dark-sidebar-active-bg: #3498DB;
+  --theme-dark-sidebar-active-text: #FFFFFF;
+  --theme-dark-sidebar-hover-bg: #34495E;
+  --theme-dark-sidebar-border: #34495E;
+  --theme-dark-sidebar-submenu-bg: rgba(0,0,0,0.15);
+  --theme-dark-sidebar-logout-text: #bdc3c7;
+  --theme-dark-sidebar-logout-hover-bg: #c0392b;
+  --theme-dark-sidebar-focus-ring: var(--theme-dark-accent-primary);
+
+  --theme-dark-footer-bg: #22272B; /* A bit darker for dark theme */
+  --theme-dark-footer-text: var(--theme-dark-text-secondary);
+}
+
+/* Apply a default theme to the body or a root app element */
+body, .theme-light {
+  background-color: var(--theme-light-bg-primary);
+  color: var(--theme-light-text-primary);
+
+  /* You can also set Bootstrap variable overrides here if not using SASS */
+  /* For example: */
+  --bs-body-bg: var(--theme-light-bg-primary);
+  --bs-body-color: var(--theme-light-text-primary);
+  --bs-primary: var(--theme-light-accent-primary);
+  --bs-primary-rgb: var(--theme-light-accent-primary-rgb);
+  --bs-secondary: var(--theme-light-accent-secondary);
+  --bs-secondary-rgb: var(--theme-light-accent-secondary-rgb);
+  --bs-success: var(--theme-light-success);
+  --bs-success-rgb: var(--theme-light-success-rgb);
+  --bs-border-color: var(--theme-light-border-primary);
+  --bs-light-bg-subtle: var(--theme-light-bg-secondary); /* For .bg-light */
+  --bs-body-bg-rgb: var(--theme-light-bg-primary-rgb);
+  --bs-body-color-rgb: var(--theme-light-text-primary-rgb);
+  --bs-link-color: var(--theme-light-text-accent);
+  --bs-link-hover-color: var(--theme-light-accent-primary-hover);
+  --bs-card-bg: var(--theme-light-bg-secondary);
+  --bs-card-border-color: var(--theme-light-border-primary);
+  --bs-card-color: var(--theme-light-text-primary);
+  --bs-secondary-bg: var(--theme-light-bg-tertiary); /* For things like contextual backgrounds */
+
+  /* Navbar specific overrides for light theme */
+  --bs-navbar-color: var(--theme-light-text-secondary);
+  --bs-navbar-hover-color: var(--theme-light-text-accent);
+  --bs-navbar-disabled-color: rgba(var(--theme-light-text-secondary-rgb, 108,117,125), 0.3);
+  --bs-navbar-active-color: var(--theme-light-text-accent);
+  --bs-navbar-brand-color: var(--theme-light-text-primary);
+  --bs-navbar-brand-hover-color: var(--theme-light-text-primary);
+  --bs-navbar-toggler-border-color: transparent; /* Example: remove toggler border */
+  /* --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,..."); custom icon if needed */
+}
+
+.theme-dark {
+  background-color: var(--theme-dark-bg-primary);
+  color: var(--theme-dark-text-primary);
+
+  /* Bootstrap overrides for dark theme */
+  --bs-body-bg: var(--theme-dark-bg-primary);
+  --bs-body-color: var(--theme-dark-text-primary);
+  --bs-primary: var(--theme-dark-accent-primary);
+  --bs-secondary: var(--theme-dark-accent-secondary);
+  --bs-border-color: var(--theme-dark-border-primary);
+  --bs-light-bg-subtle: var(--theme-dark-bg-secondary); /* For .bg-light in dark theme */
+  --bs-body-bg-rgb: var(--theme-dark-bg-primary-rgb, 26,32,44);
+  --bs-body-color-rgb: var(--theme-dark-text-primary-rgb, 247,250,252);
+  --bs-link-color: var(--theme-dark-text-accent);
+  --bs-link-hover-color: var(--theme-dark-accent-primary-hover);
+  --bs-card-bg: var(--theme-dark-bg-secondary);
+  --bs-card-border-color: var(--theme-dark-border-primary);
+  --bs-card-color: var(--theme-dark-text-primary);
+  --bs-secondary-bg: var(--theme-dark-bg-tertiary);
+}
+
+/* Basic styling for common elements using theme variables */
+a {
+  color: var(--theme-light-text-accent);
+}
+a:hover {
+  color: var(--theme-light-accent-primary-hover);
+}
+
+.theme-dark a {
+  color: var(--theme-dark-text-accent);
+}
+.theme-dark a:hover {
+  color: var(--theme-dark-accent-primary-hover);
+}
+
+/* Example: Themed card (if not relying solely on Bootstrap overrides) */
+.themed-card {
+  background-color: var(--theme-light-bg-secondary);
+  border: 1px solid var(--theme-light-border-primary);
+  color: var(--theme-light-text-primary);
+  border-radius: 0.25rem;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.theme-dark .themed-card {
+  background-color: var(--theme-dark-bg-secondary);
+  border: 1px solid var(--theme-dark-border-primary);
+  color: var(--theme-dark-text-primary);
+}
+
+/* Button theming example (if Bootstrap button overrides are not enough) */
+.btn-themed-primary {
+  background-color: var(--theme-light-accent-primary);
+  color: #fff;
+  border-color: var(--theme-light-accent-primary);
+}
+.btn-themed-primary:hover {
+  background-color: var(--theme-light-accent-primary-hover);
+  border-color: var(--theme-light-accent-primary-hover);
+}
+
+.theme-dark .btn-themed-primary {
+  background-color: var(--theme-dark-accent-primary);
+  border-color: var(--theme-dark-accent-primary);
+}
+.theme-dark .btn-themed-primary:hover {
+  background-color: var(--theme-dark-accent-primary-hover);
+  border-color: var(--theme-dark-accent-primary-hover);
+}
+
+/* This is a basic set. More variables can be added for fonts, spacing, etc. */
+/* Also, more specific overrides for Bootstrap components can be added here or by modifying SASS variables if the project uses SASS. */


### PR DESCRIPTION
Changed the default value for the `theme` prop in the Sidebar component from 'dark' to 'light'.

While the MainLayout component was already correctly passing 'light' as the theme prop, this change acts as a safeguard. If the theme prop were somehow not received as expected by the Sidebar, it will now default to 'light', aligning with the intended uniform light theme for the application.

This addresses an issue where the sidebar might have appeared dark while the rest of the application was light-themed.