### PR TITLE
feat: Allow company_admin to manage QuickBooks Online integration

### DIFF
--- a/server/routes/quickbooksRoutes.js
+++ b/server/routes/quickbooksRoutes.js
@@ -10,29 +10,30 @@ const { protect, hasRole } = require('../middleware/authMiddleware'); // Changed
 
 // @desc    Initiate QuickBooks OAuth 2.0 connection
 // @route   GET /api/quickbooks/connect
-// @access  Private (e.g., Admin, Company Owner)
-router.get('/connect', protect, hasRole(['ADMIN', 'SUPERADMIN', 'COMPANY_OWNER']), quickbooksController.connectToQuickbooks);
+// @access  Private (e.g., Admin, Company Owner, company_admin)
+router.get('/connect', protect, hasRole(['ADMIN', 'SUPERADMIN', 'COMPANY_OWNER', 'company_admin']), quickbooksController.connectToQuickbooks);
 
 // @desc    Handle QuickBooks OAuth 2.0 callback
 // @route   GET /api/quickbooks/callback
 // @access  Private (but initiated by redirect, so user context might need careful handling or rely on state)
 //          Protect middleware might run if session is maintained, otherwise state validation is key.
-router.get('/callback', protect, quickbooksController.handleQuickbooksCallback); // Protect ensures req.user is populated for state validation
+//          Adding 'company_admin' for consistency, though primary validation is state and user's companyId match.
+router.get('/callback', protect, hasRole(['ADMIN', 'SUPERADMIN', 'COMPANY_OWNER', 'company_admin']), quickbooksController.handleQuickbooksCallback); // Protect ensures req.user is populated
 
 // @desc    Get QuickBooks connection status for the company
 // @route   GET /api/quickbooks/status
-// @access  Private (e.g., Admin, Company Owner)
-router.get('/status', protect, hasRole(['ADMIN', 'SUPERADMIN', 'COMPANY_OWNER', 'FINANCE_MANAGER']), quickbooksController.getQuickbooksConnectionStatus);
+// @access  Private (e.g., Admin, Company Owner, company_admin, Finance Manager)
+router.get('/status', protect, hasRole(['ADMIN', 'SUPERADMIN', 'COMPANY_OWNER', 'FINANCE_MANAGER', 'company_admin']), quickbooksController.getQuickbooksConnectionStatus);
 
 // @desc    Disconnect from QuickBooks (revoke tokens)
 // @route   POST /api/quickbooks/disconnect
-// @access  Private (e.g., Admin, Company Owner)
-router.post('/disconnect', protect, hasRole(['ADMIN', 'SUPERADMIN', 'COMPANY_OWNER']), quickbooksController.disconnectFromQuickbooks);
+// @access  Private (e.g., Admin, Company Owner, company_admin)
+router.post('/disconnect', protect, hasRole(['ADMIN', 'SUPERADMIN', 'COMPANY_OWNER', 'company_admin']), quickbooksController.disconnectFromQuickbooks);
 
 // @desc    Sync specified payroll data to QuickBooks
 // @route   POST /api/quickbooks/sync/payroll/:payrollId
-// @access  Private (e.g., Admin, Payroll Manager)
-router.post('/sync/payroll/:payrollId', protect, hasRole(['ADMIN', 'SUPERADMIN', 'PAYROLL_MANAGER']), quickbooksController.syncPayrollToQuickbooks);
+// @access  Private (e.g., Admin, Payroll Manager, company_admin)
+router.post('/sync/payroll/:payrollId', protect, hasRole(['ADMIN', 'SUPERADMIN', 'PAYROLL_MANAGER', 'company_admin']), quickbooksController.syncPayrollToQuickbooks);
 
 
 module.exports = router;


### PR DESCRIPTION
- Updated backend QuickBooks routes (connect, callback, status, disconnect, sync payroll) to include 'company_admin' in authorized roles.
- Updated frontend QuickBooksIntegrationPage to allow access and management for 'company_admin' and other relevant admin roles (ADMIN, SUPERADMIN, COMPANY_OWNER).
- Ensured UI elements on the integration page reflect these permissions.